### PR TITLE
Add other RIRs to ranges search

### DIFF
--- a/3wifi.php
+++ b/3wifi.php
@@ -484,15 +484,15 @@ switch ($action)
 		) IPTable ORDER BY CAST(IP AS UNSIGNED INTEGER)"));
 	{
 		require 'ipext.php';
-		$last_upper = '0.0.0.0';
+		$last_upper = 0;
 		while ($row = $res->fetch_row())
 		{
-			$row[0] = (int)$row[0];
-			if (compare_ip(long2ip($row[0]), $last_upper) <= 0)
+			$ip = (int)$row[0];
+			if (compare_ip($ip, $last_upper) <= 0)
 			{
 				continue;
 			}
-			$ip_range = GetIPRange($db, $row[0]);
+			$ip_range = get_ip_range($db, $ip);
 			if(is_null($ip_range))
 			{
 				continue;
@@ -500,11 +500,13 @@ switch ($action)
 			$last_upper = $ip_range['endIP'];
 			$json['data'][] = array(
 				'range' => pretty_range($ip_range['startIP'], $ip_range['endIP']),
-				'descr' => $ip_range['descr']);
+				'netname' => $ip_range['netname'],
+				'descr' => $ip_range['descr'],
+				'country' => $ip_range['country']);
 		}
 		$res->close();
 		usort($json['data'], function($a, $b) { return strcmp($a['descr'], $b['descr']); });
-		array_unique($json['data']);
+		array_unique($json['data'], SORT_REGULAR);
 	}
 	$db->close();
 	break;

--- a/3wifi.sql
+++ b/3wifi.sql
@@ -89,7 +89,9 @@ CREATE TABLE `ranges` (
 	`id` INT(10) UNSIGNED NOT NULL AUTO_INCREMENT,
 	`startIP` INT(10) UNSIGNED NOT NULL,
 	`endIP` INT(10) UNSIGNED NOT NULL,
-	`descr` TEXT NOT NULL,
+	`netname` TINYTEXT NOT NULL,
+	`descr` TINYTEXT NOT NULL,
+	`country` CHAR(2) NOT NULL,
 	PRIMARY KEY (`id`),
 	UNIQUE INDEX `RANGE` (`startIP`, `endIP`)
 ) COLLATE='utf8_general_ci' ENGINE=InnoDB;
@@ -193,7 +195,13 @@ CREATE TABLE `favorites` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 -- Дамп данных таблицы 3wifi.users
-INSERT INTO `users` (`uid`, `puid`, `login`, `nick`, `pass_hash`, `autologin`, `salt`, `level`, `ip_hash`, `maxInvites`) VALUES
-	(0, 0, 'root', '3WiFi System', '', '', '', -1, '', 0);
-INSERT INTO `users` (`uid`, `puid`, `login`, `nick`, `pass_hash`, `autologin`, `salt`, `level`, `ip_hash`, `maxInvites`) VALUES
-	(1, 0, 'admin', 'Administrator', 'hash = md5(pass.salt)', '', 'salt = md5(invite)', 3, '', 65535);
+INSERT INTO `users` SET
+	`regdate`=CURRENT_TIMESTAMP,
+	`login`='admin',
+	`nick`='Administrator',
+	`salt`='2p8a!m%EFHr).djHO1uuIA^x82X$(988',
+	`pass_hash`=MD5(CONCAT('admin',`salt`)),
+	`autologin`='',
+	`level`=3,
+	`ip_hash`='',
+	`invites`=65535;

--- a/ipext.php
+++ b/ipext.php
@@ -1,127 +1,432 @@
 <?php
-function cURL_Get($url)
+
+// Regional Internet Registries
+define('RIR_RIPE', 1);
+define('RIR_APNIC', 2);
+define('RIR_ARIN', 3);
+define('RIR_AFRINIC', 4);
+define('RIR_LACNIC', 5);
+
+/**
+ * Fetch data for ip object using RDAP.
+ *
+ * @param string $url Path to RDAP service.
+ * @param string $ip IP address to search for.
+ *
+ * @return object|null Response encoded in json as PHP object.
+ */
+function fetch_rdap($url, $ip)
 {
 	$ch = curl_init();
 	curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
 	curl_setopt($ch, CURLOPT_ENCODING, 'utf-8');
-	curl_setopt($ch, CURLOPT_TIMEOUT, 3);
 	curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, 0);
 	curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, 0);
 	curl_setopt($ch, CURLOPT_USERAGENT, 'PHP/'.phpversion());
-	curl_setopt($ch, CURLOPT_URL, $url);
-	$data = curl_exec($ch);
+	curl_setopt($ch, CURLOPT_TIMEOUT, 10);
+	
+	curl_setopt($ch, CURLOPT_URL, $url.'ip/'.$ip);
+	curl_setopt($ch, CURLOPT_HTTPHEADER, 
+		array("Accept: application/json, application/rdap+json"));
+	curl_setopt($ch, CURLOPT_FOLLOWLOCATION, 1);
+	
+	$res = curl_exec($ch);
+	//$ret_code = curl_getinfo($ch, CURLINFO_HTTP_CODE);
 	curl_close($ch);
-	return $data;
+
+	//if ($ret_code != 200) {
+	//	return;
+	//}
+	return json_decode($res);
 }
 
-function QueryRangeFromRIPE($IP)
+/**
+ * Fetch information from whois server.
+ *
+ * @param string $server Server address.
+ * @param string $request Requset string.
+ *
+ * @return string|null Response of whois server.
+ */
+function fetch_whois($server, $request)
 {
-	$IP = long2ip($IP);
-	$data = cURL_Get("http://rest.db.ripe.net/search.json?type-filter=inetnum&flags=one-less&flags=no-irt&flags=no-referenced&query-string=$IP");
-	$json = json_decode($data);
-	if (is_null($json))
+	$fp = fsockopen($server, 43, $errno, $errstr, 30);
+	if (!$fp)
 	{
 		return;
 	}
-	$atribute = $json->objects->object[0]->attributes->attribute;
-	$inetnum = array_filter($atribute, function($obj) { return $obj->name == 'inetnum'; });
-	$inetnum = $inetnum[0]->value;
-	$inetnum = explode(" - ", $inetnum);
-	$descr = implode(
-		" | ",
-		array_map(
-			function($obj){return $obj->value;},
-			array_filter($atribute, function($obj) { return $obj->name == 'descr'; })
-		)
-	);
-	return array('startIP' => $inetnum[0],
-		'endIP' => $inetnum[1],
-		'descr' => $descr);
+	else
+	{
+		$response = "";
+		fputs($fp, "$request\r\n");
+		while (!feof($fp))
+		{
+			$response .= fread($fp,128);
+		}
+		fclose ($fp);
+	}
+	return $response;
 }
 
-function GetIPRange($db, $IP)
+/**
+ * Determine RIR for given IP.
+ *
+ * @param string $ip IP address.
+ *
+ * @return int|null.
+ */
+function get_rir($ip)
 {
-	// If invalid
-	if ($IP == false || $IP == -1)
+	// use ARIN server in hope that it will redirect to right one (if neccessary)
+	$rdap = fetch_rdap('http://rdap.arin.net/registry/', $ip);
+	if (is_null($rdap) || empty($rdap->port43))
 	{
 		return;
 	}
+	
+	$whois = $rdap->port43;
+	if (false !== stristr($whois, 'afrinic'))
+	{
+		return RIR_AFRINIC;
+	}
+	elseif (false !== stristr($whois, 'apnic'))
+	{
+		return RIR_APNIC;
+	}
+	elseif (false !== stristr($whois, 'arin'))
+	{
+		return RIR_ARIN;
+	}
+	elseif (false !== stristr($whois, 'lacnic'))
+	{
+		return RIR_LACNIC;
+	}
+	elseif (false !== stristr($whois, 'ripe'))
+	{
+		return RIR_RIPE;
+	}
+	return;
+}
 
+/**
+ * Extract value of field with given name from the response of whois server.
+ *
+ * @param string $whois_text Whois server response.
+ * @param string $field_name Field name to search for.
+ *
+ * @return string Value of the first field with given name.
+ */
+function get_whois_field($whois_text, $field_name)
+{
+	$field_pos = strpos($whois_text, "\n".$field_name.":");
+	if ($field_pos === False)
+	{
+		return '';
+	}
+	$field_pos += strlen($field_name) + 2;
+	$field_len = strpos($whois_text, "\n", $field_pos) - $field_pos;
+	return trim(substr($whois_text, $field_pos, $field_len));
+}
+
+/**
+ * Extract values of subsequent fields with given name from the response of whois server.
+ *
+ * @param string $whois_text Whois server response.
+ * @param string $field_name Field name to search for.
+ *
+ * @return array Array of strings.
+ */
+function get_whois_field_arr($whois_text, $field_name)
+{
+	$field_pos = strpos($whois_text, "\n".$field_name.":");
+	if ($field_pos === False)
+	{
+		return array('');
+	}
+	do
+	{
+		$value_pos = $field_pos + strlen($field_name) + 2;
+		$value_len = strpos($whois_text, "\n", $value_pos) - $value_pos;
+		$values[] = trim(substr($whois_text, $value_pos, $value_len));
+		$field_pos = strpos($whois_text, "\n".$field_name.":", $value_pos);
+	} while ($field_pos !== False and $field_pos == $value_pos + $value_len);
+	return $values;
+}
+
+/**
+ * Get boundaries of a range in CIDR notation.
+ *
+ * @param string $cidr IP range (x.x.x.x/z, x.x.x/z, ...).
+ *
+ * @return array Array ("startIP" => (int), "endIP" => (int)).
+ */
+function cidr_to_range($cidr)
+{
+	list($ip, $mask) = explode('/', $cidr);
+	$i = substr_count($ip, '.');
+	while ($i < 3)
+	{
+		$ip .= '.0';
+		$i++;
+	}
+	$ip = ip2long($ip);
+	return array('startIP' => $ip,
+		// will not work on 32bit if $mask=0; but it doesn't matter here
+		'endIP' => $ip | ((1<<(32-$mask)) - 1)); 
+}
+
+/**
+ * Query RIR for a range to which belongs the given IP address.
+ *
+ * @param int $ip IP address as number.
+ *
+ * @return array|null Array ("startIP" => (int), "endIP" => (int), "netname" =>
+ * (string), "descr" => (string), "country" => (string)) or null if nothing is 
+ * found.
+ */
+function query_range_from_rir($ip)
+{
+	$rir = get_rir($ip);
+	if (is_null($rir))
+	{
+		return;
+	}
+	
+	$whois_servers = array(
+		RIR_RIPE => 'whois.ripe.net',
+		RIR_APNIC => 'whois.apnic.net',
+		RIR_ARIN => 'whois.arin.net',
+		RIR_AFRINIC => 'whois.afrinic.net',
+		RIR_LACNIC => 'whois.lacnic.net');
+	$whois_req = $ip;
+	if ($rir == RIR_ARIN )
+	{
+		$whois_req = 'n + '.$ip;
+	}
+	$whois_res = fetch_whois($whois_servers[$rir], $whois_req);
+	if ($whois_res == '')
+	{
+		return;
+	}
+	
+	switch ($rir)
+	{
+		case RIR_RIPE:
+			// the same as RIR_APNIC
+		case RIR_AFRINIC:
+			// the same as RIR_APNIC
+		case RIR_APNIC:
+			$inetnum = get_whois_field($whois_res, 'inetnum');
+			if ($inetnum == '')
+			{
+				return;
+			}
+			$inetnum = preg_split('/\s*-\s*/', $inetnum);
+			$netname = get_whois_field($whois_res, 'netname');
+			$descr = implode(" | ", get_whois_field_arr($whois_res, 'descr'));
+			if ($rir == RIR_RIPE)
+			{
+				$descr = iconv("ISO-8859-1", "UTF-8", $descr);
+			}
+			$country = strtoupper(get_whois_field($whois_res, 'country'));
+			return array('startIP' => ip2long($inetnum[0]),
+				'endIP' => ip2long($inetnum[1]),
+				'netname' => $netname,
+				'descr' => $descr,
+				'country' => $country);
+			break;
+		case RIR_ARIN:
+			// find the smallest range
+			$start_pos = -1;
+			$ip_count = array();
+			while (($start_pos = strpos($whois_res, "\n# start", $start_pos + 1)) !== False)
+			{
+				$end_pos = strpos($whois_res, "\n# end", $start_pos);
+				$inetnum = get_whois_field(substr($whois_res, $start_pos, $end_pos - $start_pos), 'NetRange');
+				if ($inetnum != '')
+				{
+					$inetnum = preg_split('/\s*-\s*/', $inetnum);
+					$ip_count[$start_pos] = ip2long($inetnum[1]) - ip2long($inetnum[0]);
+				}
+			}
+			if (!empty($ip_count))
+			{
+				$start_pos = array_search(min($ip_count), $ip_count);
+				$end_pos = strpos($whois_res, "\n# end", $start_pos);
+				$whois_res = substr($whois_res, $start_pos, $end_pos - $start_pos);
+			}
+			
+			$inetnum = get_whois_field($whois_res, 'NetRange');
+			if ($inetnum == '')
+			{
+				return;
+			}
+			
+			$inetnum = preg_split('/\s*-\s*/', $inetnum);
+			$netname = get_whois_field($whois_res, 'NetName');
+			$descr = get_whois_field($whois_res, 'OrgName');
+			if ($descr == '')
+			{
+				$descr = get_whois_field($whois_res, 'CustName');
+			}
+			$country = strtoupper(get_whois_field($whois_res, 'Country'));
+			return array('startIP' => ip2long($inetnum[0]),
+				'endIP' => ip2long($inetnum[1]),
+				'netname' => $netname,
+				'descr' => $descr,
+				'country' => $country);
+			break;
+		case RIR_LACNIC:
+			$inetnum = get_whois_field($whois_res, 'inetnum');
+			if ($inetnum == '')
+			{
+				return;
+			}
+			$inetnum = cidr_to_range($inetnum);
+			$netname = get_whois_field($whois_res, 'netname');
+			$descr = get_whois_field($whois_res, 'owner');
+			$descr = iconv("ISO-8859-1", "UTF-8", $descr);
+			$country = strtoupper(get_whois_field($whois_res, 'country'));
+			return array('startIP' => $inetnum["startIP"],
+				'endIP' => $inetnum["endIP"],
+				'netname' => '',
+				'descr' => $descr,
+				'country' => $country);
+			break;
+	}
+}
+
+/**
+ * Find a range to which belongs the given IP address.
+ *
+ * If IP doesn't belong to one of ranges stored in local database, it will try 
+ * to fetch information from appropriate Regional Internet Registry (RIR).
+ *
+ * @param object $db Object which represents the connection to a MySQL Server.
+ * @param int $ip IP address as number.
+ *
+ * @return array|null Array ("startIP" => (int), "endIP" => (int), "netname" =>
+ * (string), "descr" => (string), "country" => (string)) or null if nothing is 
+ * found.
+ */
+function get_ip_range($db, $ip)
+{
 	// If private IP
-	$ip_arr = explode('.', long2ip($IP));
-	if ($ip_arr[0] == 10 ||
-		($ip_arr[0] == 100 && $ip_arr[1] >= 64 && $ip_arr[1] < 128) ||
-		($ip_arr[0] == 172 && $ip_arr[1] >= 16 && $ip_arr[1] < 32) ||
-		($ip_arr[0] == 192 && $ip_arr[1] == 168))
+	if (($ip >= (int)0x0A000000 and $ip < (int)0x0B000000) or // 10.0.0.0-10.255.255.255
+		($ip >= (int)0x64400000 and $ip < (int)0x64800000) or // 100.64.0.0-100.127.255.255
+		($ip >= (int)0xAC100000 and $ip < (int)0xAC200000) or // 172.16.0.0-172.31.255.255
+		($ip >= (int)0xC0A80000 and $ip < (int)0xC0A90000))   // 192.168.0.0-192.168.255.255
 	{
-		$two_oct = $ip_arr[0].'.'.$ip_arr[1];
-		return array('startIP' => $two_oct.'.0.0',
-			'endIP' => $two_oct.'.255.255',
-			'descr' => 'Local IP range');
+		// exact range isn't known, just use /16 mask
+		return array('startIP' => $ip & ~0xFFFF,
+			'endIP' => $ip | 0xFFFF,
+			'netname' => '',
+			'descr' => 'Local IP range',
+			'country' => '');
 	}
-
+	
 	// If stored in local db
-	$uIP = sprintf('%u', $IP);
+	$uIP = sprintf('%u', $ip);
 	if ($res = $db->query(
-		"SELECT * FROM ranges
-		WHERE startIP <= $uIP AND endIP >= $uIP
-		ORDER BY endIP-startIP
-		LIMIT 1"))
+			"SELECT * FROM ranges
+			WHERE startIP <= $uIP AND endIP >= $uIP
+			ORDER BY endIP-startIP
+			LIMIT 1"))
 	{
 		if ($row = $res->fetch_row())
 		{
-			return array('startIP' => long2ip($row[1]),
-				'endIP' => long2ip($row[2]),
-				'descr' => $row[3]);
+			$res->close();
+			// TODO: convert unsigned integer (represented by string) to int
+			return array('startIP' => ip2long(long2ip($row[1])),
+				'endIP' => ip2long(long2ip($row[2])),
+				'netname' => $row[3],
+				'descr' => $row[4],
+				'country' => $row[5]);
 		}
 		$res->close();
 	}
-
-	// Query RIPE db
-	$ip_range = QueryRangeFromRIPE($IP);
+	
+	// Query RIR
+	$ip_range = query_range_from_rir(long2ip($ip));
 	if(is_null($ip_range))
 	{
 		return;
 	}
-	$startIP = ip2long($ip_range["startIP"]);
-	$endIP = ip2long($ip_range["endIP"]);
-	if ($startIP == false || $startIP == -1 || $endIP == false || $endIP == -1)
+	$ip_range["netname"] = substr($ip_range["netname"], 0, 255);
+	$ip_range["descr"] = substr($ip_range["descr"], 0, 255);
+	$ip_range["descr"] = iconv("UTF-8", "UTF-8//IGNORE", $ip_range["descr"]);
+	if ($ip_range["endIP"] - $ip_range["startIP"] >= 0x00FFFFFF)
 	{
-		return;
+		return $ip_range; // don't store big ranges
 	}
-	$startIP = sprintf('%u', $startIP);
-	$endIP = sprintf('%u', $endIP);
+	$ip_range["country"] = substr($ip_range["country"], 0, 2);
+	$startIP = sprintf('%u', $ip_range["startIP"]);
+	$endIP = sprintf('%u', $ip_range["endIP"]);
+	$netname = $db->real_escape_string($ip_range["netname"]);
 	$descr = $db->real_escape_string($ip_range["descr"]);
-	if (!$db->query("INSERT into ranges VALUES (NULL, '$startIP','$endIP','$descr')"))
+	$country = $db->real_escape_string($ip_range["country"]);
+	if (!$db->query(
+			"INSERT into ranges
+			VALUES (NULL, '$startIP','$endIP','$netname','$descr','$country')"))
 	{
 		return;
 	}
-	return array('startIP' => $ip_range["startIP"],
-		'endIP' => $ip_range["endIP"],
-		'descr' => $ip_range["descr"]);
+	return $ip_range;
 }
 
-function compare_ip($IP1, $IP2)
+/**
+ * Compare two IP addresses.
+ * 
+ * It's a workaround for 32-bit machines, where (since int type is signed) 
+ * IPs bigger then '127.255.255.255' are negative numbers.
+ * 
+ * @param int $ip1 Numeric representation of the first IP.
+ * @param int $ip2 Numeric representation of the second IP.
+ * 
+ * @return int Returns zero if addresses are equal, -1 if the first is smaller 
+ * and 1 otherwise.
+ */
+function compare_ip($ip1, $ip2)
 {
-	$ip_arr1 = explode('.', $IP1);
-	$ip_arr2 = explode('.', $IP2);
-	for($i = 0; $i < 4; $i++)
+	if ($ip1 == $ip2)
 	{
-		if ($ip_arr1[$i] < $ip_arr2[$i]) {return -1;}
-		else if ($ip_arr1[$i] > $ip_arr2[$i]) {return 1;}
+		return 0;
 	}
-	return 0;
+	elseif ($ip1 < 0 and $ip2 >=0)
+	{
+		return 1;
+	}
+	elseif ($ip1 >= 0 and $ip2 < 0)
+	{
+		return -1;
+	}
+	elseif ($ip1 < $ip2)
+	{
+		return -1;
+	}
+	else
+	{
+		return 1;
+	}
 }
 
-function pretty_range($IP1, $IP2)
+/**
+ * Return string representation of IP range.
+ * 
+ * Convert IP range to CIDR specification (x.x.x.x/z) if it may be expressed as 
+ * single entity. Otherwise format it to "x.x.x.x-y.y.y.y".
+ *
+ * @param int $ip1 Lower boundary of the range.
+ * @param int $ip2 Upper boundary of the range.
+ *
+ * @return string
+ */
+function pretty_range($ip1, $ip2)
 {
-	$ip_long1 = ip2long($IP1);
-	$ip_long2 = ip2long($IP2);
-	$diff = decbin($ip_long1 ^ $ip_long2);
-	if (strpos($diff, '0') === false && ($ip_long1 & $ip_long2) == $ip_long1)
+	$diff = decbin($ip1 ^ $ip2);
+	if (strpos($diff, '0') === false and ($ip1 & $ip2) == $ip1)
 	{
-		return $IP1.'/'.(32 - strlen($diff));
+		return long2ip($ip1).'/'.(32 - strlen($diff));
 	}
-	return $IP1.'-'.$IP2;
+	return long2ip($ip1).'-'.long2ip($ip2);
 }
-?>

--- a/ranges.html
+++ b/ranges.html
@@ -10,8 +10,8 @@ function find()
 	$('#tranges').css('display', 'none');
 	$('#fdata').empty();
 	$('#fhead').empty();
-	$('#fhead').append('<tr><th>IP Range</th><th>Description</th></tr>');
-	$('#fdata').append('<tr><td colspan=2><img src="img/loading.gif"></td></tr>');
+	$('#fhead').append('<tr><th>IP Range</th><th>Netname</th><th>Description</th><th>Country</th></tr>');
+	$('#fdata').append('<tr><td colspan=4><img src="img/loading.gif"></td></tr>');
 
 	$.post('3wifi.php?a=ranges', formdata, function(d)
 	{
@@ -36,10 +36,11 @@ function find()
 		{
 			$('#fdata').empty();
 			$('#fhead').empty();
-			$('#fhead').append('<tr><th>IP Range</th><th>Description</th></tr>');
+			$('#fhead').append('<tr><th>IP Range</th><th>Netname</th><th>Description</th><th>Country</th></tr>');
 			for (var i = 0; i < d.data.length; i++)
 			{
-				$('#fdata').append('<tr><td>'+d.data[i].range+'</td><td>'+d.data[i].descr+'</td></tr>');
+				$('#fdata').append('<tr><td>'+d.data[i].range+'</td><td>'+d.data[i].netname+'</td><td>'+
+					d.data[i].descr+'</td><td>'+d.data[i].country+'</td></tr>');
 			}
 		} else {
 			$('#fdata > tr:first-child > :first-child').text('Ничего не найдено.');
@@ -53,7 +54,7 @@ function rangesText()
 	for (var i = 0; i < data.length; i++)
 	{
 		var td = $(data[i]);
-		if (td.prop('colspan') == 2) continue;
+		if (td.prop('colspan') == 4) continue;
 		str += td.text()+"\r\n";
 	}
 	return str;
@@ -78,9 +79,9 @@ function initpage()
 <form id=frangesform enctype="multipart/form-data" method="POST" onsubmit="find(); return false">
 <table>
 	<tbody>
-		<tr><td>Latitude / Широта:</td><td><input name="latitude" type="number" value="%var_lat%" /></td><td>° [-90; 90]</td></tr>
-		<tr><td>Longitude / Долгота:</td><td><input name="longitude" type="number" value="%var_lon%" /></td><td>° [-180; 180]</td></tr>
-		<tr><td>Search radius / Радиус поиска:</td><td><input name="radius" type="number" value="%var_rad%" /></td><td>км (max 25)</td></tr>
+		<tr><td>Latitude / Широта:</td><td><input name="latitude" type="number" min="-90" max="90" step="0.000001" value="%var_lat%" /></td><td>° [-90; 90]</td></tr>
+		<tr><td>Longitude / Долгота:</td><td><input name="longitude" type="number" min="-180" max="180" step="0.000001" value="%var_lon%" /></td><td>° [-180; 180]</td></tr>
+		<tr><td>Search radius / Радиус поиска:</td><td><input name="radius" type="number" min="0" max="25" step="0.1" value="%var_rad%" /></td><td>км (max 25)</td></tr>
 	</tbody>
 	<tbody>
 		<tr><td><input type=submit value="Найти" /> <button onclick="listRanges(); return false">Список</button></td><td></td></tr>


### PR DESCRIPTION
In addition to the RIPE other Regional Internet Registrars (ARIN, APNIC,
AFRINIC and LACNIC) have been added. WHOIS servers are used to retrieve IP
range info.
Also  added `netname` and `country` columns to `ranges` table.
![ranges](https://cloud.githubusercontent.com/assets/14203625/11881793/15d33ae0-a51a-11e5-87ed-4adca4b30960.png)
