### PR TITLE
Oui24bit pin

### DIFF
--- a/wpspin.html
+++ b/wpspin.html
@@ -539,7 +539,6 @@ TP-Link TD-W8961ND v2.1
   F8:1A:67:XX:XX:XX
   F8:D1:11:XX:XX:XX
 	
-	
 %l10n_wpspin_tech%
 Pin = MAC[7..12]</textarea>
 

--- a/wpspin.html
+++ b/wpspin.html
@@ -510,7 +510,36 @@ Belkin F9K1104v1
   08:86:3B:xx:xx:xx
 Tenda W309R
   C8:3A:35:xx:xx:xx
-
+  00:B0:0C:XX:XX:XX
+  08:10:75:XX:XX:XX	
+Conceptronic C300BRS4A
+  00:22:F7:XX:XX:XX
+Hitron CDE-30364
+  00:26:5B:XX:XX:XX
+  68:B6:CF:XX:XX:XX
+  78:8D:F7:XX:XX:XX
+  BC:14:01:XX:XX:XX
+MitraStar HGW-2501GN-R2 
+  B2:46:FC:XX:XX:XX
+  E2:41:36:XX:XX:XX
+Samsung SMT-G7440
+  5C:A3:9D:XX:XX:XX
+  DC:71:44:XX:XX:XX
+  D8:6C:E9:XX:XX:XX
+Samsung SWL (Samsung Wireless Link) 	
+  E4:7C:F9:XX:XX:XX
+  80:1F:02:XX:XX:XX
+Teldat iRouter1104-W
+  00:A0:26:XX:XX:XX
+TP-Link TD-W8951ND
+  A0:F3:C1:XX:XX:XX
+TP-Link TD-W8961ND v2.1
+  64:70:02:XX:XX:XX
+  B0:48:7A:XX:XX:XX
+  F8:1A:67:XX:XX:XX
+  F8:D1:11:XX:XX:XX
+	
+	
 %l10n_wpspin_tech%
 Pin = MAC[7..12]</textarea>
 


### PR DESCRIPTION
Little contribution from spain and other place using the data base of WPS PIN (bash script created in 2012). The data base has been updated over the years and it is freely available here: [https://www.wifi-libre.com/topic-626-base-de-datos-wpspin-original-open-source-actualizada.html](url)
Notice that the algorithm was found in 2012 by  ZaoChunsheng and published in the script ComputePIN-C83A35 (for more information check [)](http://hellocow.cn/2012/04/get-the-pin-in-router-mac-address-start-with-c83a35-00b00c-081075/) 
It is known as "Zao algorithm", at least in some part of the globe :smiley_cat: 
Al this data are 100% safe/complete and I checked them personally. They've been collected over five year with contribution from users from several forums,. mainly Spanish and French.
Some more will come. 
Cheers! 